### PR TITLE
add specific response code error handling to query

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,17 +1,21 @@
 <html>
-    <head>
-        <script src="/dist/index.js" type="module"></script>
-    </head>
-    <script type="module">
-        import { query } from "/dist/index.js";
-        const { blockNumber, result } = await query({
-            chainId: 8453n,
-            eventSignatures: [],
-            query: "select block_num from logs limit 1",
-        });
-        document.querySelector("body pre").textContent = JSON.stringify({ blockNumber, result });
-    </script>
-    <body>
-        <pre></pre>
-    </body>
+  <head>
+    <script src="/dist/index.js" type="module"></script>
+  </head>
+  <script type="module">
+    import { queryLive, setLogLevel, LogLevel } from "/dist/index.js";
+    setLogLevel(LogLevel.DEBUG);
+    const { blockNumber, result } = await query({
+      chainId: 8453n,
+      eventSignatures: [],
+      query: "select block_num from logs limit 1",
+    });
+    document.querySelector("body pre").textContent = JSON.stringify({
+      blockNumber,
+      result,
+    });
+  </script>
+  <body>
+    <pre></pre>
+  </body>
 </html>

--- a/examples/live.ts
+++ b/examples/live.ts
@@ -1,5 +1,6 @@
-import { queryLive } from "../src/index.ts";
+import { queryLive, LogLevel, setLogLevel } from "../src/index.ts";
 
+setLogLevel(LogLevel.DEBUG);
 type Hex = `0x${string}`;
 
 type Transfer = {
@@ -16,7 +17,7 @@ let latest = 23815440n;
 
 const query = queryLive({
   abortSignal: controller.signal,
-  startBlock: () => (latest + 1n),
+  startBlock: () => latest + 1n,
   chainId: 8453n,
   eventSignatures: [
     "Transfer(address indexed from, address indexed to, uint256 v)",

--- a/examples/single.ts
+++ b/examples/single.ts
@@ -1,5 +1,7 @@
-import { query } from "../src/index.ts";
+import { query, setLogLevel, LogLevel } from "../src/index.ts";
 
+// Set the log level to DEBUG
+setLogLevel(LogLevel.DEBUG);
 type Address = `0x${string}`;
 
 const { blockNumber, result } = await query({

--- a/src/index.ts
+++ b/src/index.ts
@@ -395,6 +395,16 @@ export async function* queryLive<T = DefaultType>(
         signal: AbortSignal.any(signals),
       });
 
+      if (response.status === 429) {
+        throw `Rate limited, retrying in ${config.delay}ms`;
+      } else if (response.status === 408) {
+        debug("Timeout error, retrying...");
+        // retry immediately
+        continue;
+      } else if (response.status >= 400 && response.status < 500) {
+        throw Error("InvalidRequest");
+      }
+
       if (!response.body) {
         throw new Error(`Index Supply API response missing body`);
       }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { query, queryLive, setLogLevel, LogLevel } from "../src/index";
+import { query, queryLive, setLogLevel, LogLevel, debug } from "../src/index";
 
 setLogLevel(LogLevel.DEBUG);
 test("query", async (t) => {
@@ -76,5 +76,28 @@ test("queryLive", async (t) => {
       ]);
       controller.abort();
     }
+  });
+
+  await t.test("should throw", async () => {
+    await assert.rejects(
+      async () => {
+        const query = await queryLive({
+          chainId: 8453n,
+          eventSignatures: [
+            "Transfer(address indexed from, address indexed to, uint256 value)",
+          ],
+          query: "bad query",
+        });
+        for await (const { result } of query) {
+          result.forEach((row) => {
+            debug(`Transaction: ${row.tx}, Block: ${row.block}\n`);
+          });
+        }
+      },
+      (err: any) => {
+        assert.strictEqual(err.message, "InvalidRequest");
+        return true;
+      },
+    );
   });
 });


### PR DESCRIPTION
This implements a similar style retry logic as we do in `queryLive`. This came up because of how we want to handle different error responses, e.g. 408 should retry immediately, 429 should do a delayed retry, and 400 should exit immediately.

One thing I wanted to ask about, in the case of a 400 is possible, or might customers want to see the error e.g. `unable to make request: User("column \"asdfasdf\" does not exist")` in the response?

Update:

I reworked some of the error handling for `queryLive` as well, in my testing I found that the errors that we see during the SSE responses look like this:

  - Bad request
    - Browser: 
      - name: TypeError
      - message: NetworkError when attempting to fetch resource.
    - Node: 
      - name: TypeError
      - message: terminated

  - Server down
    - Browser: 
      - name: TypeError
      - message: NetworkError when attempting to fetch resource.
    - Node: 
      - name: TypeError
      - message: fetch failed

I added an immediate throw for the node "terminated" error as that seems to be the behavior of the 400 style error while we are in the SSE session, and added a test as well. Unfortunately the browser is very general with errors during the SSE session, and I wasn't able to receive any more detailed info when trying to introspect.