### PR TITLE
deal with sse errors in stream. refactor

### DIFF
--- a/examples/live.ts
+++ b/examples/live.ts
@@ -1,4 +1,6 @@
-import { queryLive } from "../src/index.ts";
+import { queryLive, setLogLevel, LogLevel } from "../src/index.ts";
+
+setLogLevel(LogLevel.DEBUG);
 
 type Hex = `0x${string}`;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ export const setLogHandler = (
   currentConfig.logHandler = handler;
 };
 
-export const log = (
+const log = (
   level: LogLevel,
   message: string,
   ...args: unknown[]
@@ -40,48 +40,47 @@ export const log = (
   }
 };
 
-export const error = (message: string, ...args: unknown[]): void => {
+const logError = (message: string, ...args: unknown[]): void => {
   log(LogLevel.ERROR, message, ...args);
 };
 
-export const warn = (message: string, ...args: unknown[]): void => {
-  log(LogLevel.WARN, message, ...args);
-};
-
-export const info = (message: string, ...args: unknown[]): void => {
-  log(LogLevel.INFO, message, ...args);
-};
-
-export const debug = (message: string, ...args: unknown[]): void => {
+const logDebug = (message: string, ...args: unknown[]): void => {
   log(LogLevel.DEBUG, message, ...args);
 };
 
-async function retry<T>(f: () => Promise<T>): Promise<T> {
-  let finalError;
-  for (let i = 1; ; i++) {
-    try {
-      return await f();
-    } catch (e) {
-      finalError = e;
-      if (i <= 5) {
-        const timeout = Math.min(500, 100 * 2 ** i);
-        await delay(timeout);
-      } else {
-        debug(`error ${e} retrying ${5 - i} more times.`);
-        break;
-      }
+class EUser extends Error { constructor(s: string) { super(s); } }
+class EWait extends Error { constructor(s: string) { super(s); } }
+class ERetry extends Error { constructor(s: string) { super(s); } }
+
+class ErrorHandler {
+  public last: Error;
+  constructor() { this.last = new Error(); }
+
+  async error(msg: string, error: any) {
+    if (error instanceof Error) this.last = error;
+    if (error instanceof EWait) {
+      logError(`${msg} ${error} waiting before retry`);
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    } else if (error instanceof ERetry) {
+      logError(`${msg} ${error} retrying now`);
+    } else if (error instanceof EUser) {
+      logError(`${msg} ${error} user error. not retrying`);
+      throw error;
+    } else {
+      logError(`${msg} ${error}`);
     }
   }
-  throw finalError;
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export type JsonValue = ReturnType<typeof JSON.parse>;
 export type Formatter<T> = (row: JsonValue[]) => T;
 type DefaultType = { [key: string]: JsonValue };
+
+// Alias fetch's request and response
+// so that we can use the words: Request, Response
+const FetchRequest = Request;
+type FetchRequest = globalThis.Request;
+type FetchResponse = globalThis.Response;
 
 /**
  * Represents a request to the API
@@ -186,8 +185,8 @@ const defaultFormatRow = (names: string[]): Formatter<DefaultType> => {
   };
 };
 
-function parseJSON<T>(payload: string, formatRow?: Formatter<T>): Response<T> {
-  const parsed = JSON.parse(payload);
+
+function parseResponse<T>(parsed: any, formatRow?: Formatter<T>): Response<T> {
   if (parsed.result.length === 0) {
     return { blockNumber: parsed.block_height, result: [] };
   }
@@ -200,6 +199,40 @@ function parseJSON<T>(payload: string, formatRow?: Formatter<T>): Response<T> {
     blockNumber: parsed.block_height,
     result: result.map(formatRow || defaultFormatRow(columnNames)),
   };
+}
+
+async function sendRequest(
+  request: FetchRequest,
+  signal?: AbortSignal
+): Promise<FetchResponse> {
+  logDebug(`sending request to ${request.url}`);
+  try {
+    const response = await fetch(request, {
+      signal,
+    });
+    if ((response.status / 100) === 2) {
+      return response;
+    } else if (response.status === 408) {
+      throw new ERetry("timeout");
+    } else if (response.status === 429) {
+      throw new EWait("too many requests");
+    } else if (response.status === 404) {
+      throw new EUser(`not found ${request.url}`);
+    } else if ((response.status / 100) === 4) {
+      const responseBody = await response.text();
+      try {
+        const data = JSON.parse(responseBody);
+        throw new EUser(data["message"]);
+      } catch {
+        throw new EUser(responseBody);
+      }
+    } else {
+      const responseBody = await response.text();
+      throw new EWait(`${response.status} ${responseBody}`);
+    }
+  } catch (e) {
+    throw new EWait(`unkown error ${e}`);
+  }
 }
 
 /**
@@ -232,15 +265,21 @@ function parseJSON<T>(payload: string, formatRow?: Formatter<T>): Response<T> {
  * });
  */
 export async function query<T = DefaultType>(
-  request: Request<T>,
+  userRequest: Request<T> & {
+    abortSignal?: AbortSignal;
+    retryAttempts?: number,
+  },
 ): Promise<Response<T>> {
-  return await retry(async () => {
-    const resp = await fetch(url("query", request));
-    if (resp.status !== 200) {
-      throw new Error(`Invalid API response: Status ${resp.status}`);
+  const handle = new ErrorHandler();
+  for (let attempt = 0; attempt < (userRequest.retryAttempts ?? 5); attempt++) {
+    try {
+      const response = await sendRequest(new FetchRequest(url("query", userRequest)));
+      return parseResponse(await response.json(), userRequest.formatRow);
+    } catch (e) {
+      await handle.error("query", e);
     }
-    return parseJSON(await resp.text(), request.formatRow);
-  });
+  }
+  throw handle.last;
 }
 
 type Stream = ReadableStreamDefaultReader<Uint8Array>;
@@ -252,7 +291,7 @@ async function* readStream(reader: Stream): AsyncGenerator<JsonValue> {
     if (done) return;
     let payload = decoder.decode(value);
     if (payload.startsWith("data: ")) {
-      payload = payload.substring(6);
+      payload = payload.substring(6).trimEnd();
     } else {
       continue;
     }
@@ -262,27 +301,6 @@ async function* readStream(reader: Stream): AsyncGenerator<JsonValue> {
 
 export type startBlock = () => bigint;
 
-/**
- * maxAttempts - The maximum number of attempts before giving up
- * baseDelay - The initial delay in milliseconds
- * maxDelay - The maximum delay in milliseconds
- * delay - The current delay in milliseconds
- */
-interface RetryConfig {
-  maxAttempts?: number;
-  baseDelay: number;
-  maxDelay: number;
-}
-
-/**
- * By default retries will happen indefinitely, set maxAttempts to limit the number of retries
- */
-const DEFAULT_RETRY_CONFIG: RetryConfig = {
-  baseDelay: 1000,
-  maxDelay: 10000,
-};
-
-const DEFAULT_TIMEOUT = 60_000;
 /**
  * Creates a live query connection that yields results as the API indexes new blocks
  * @template T The type of the formatted results
@@ -324,95 +342,36 @@ const DEFAULT_TIMEOUT = 60_000;
  */
 export async function* queryLive<T = DefaultType>(
   userRequest: Request<T> & {
-    abortSignal?: AbortSignal;
     startBlock?: startBlock;
-    retryConfig?: Partial<RetryConfig>;
-    timeout?: number;
+    abortSignal?: AbortSignal;
+    retryAttempts?: number,
   },
 ): AsyncGenerator<Response<T>, void, unknown> {
   let userRequestedAbort = false;
-  let attempt = 0;
-  const config = {
-    ...DEFAULT_RETRY_CONFIG,
-    timeout: userRequest.timeout ?? DEFAULT_TIMEOUT,
-    ...userRequest.retryConfig,
-    get delay(): number {
-      return Math.min(this.baseDelay * Math.pow(2, attempt - 1), this.maxDelay);
-    },
-  };
-
   userRequest.abortSignal?.addEventListener("abort", () => {
     userRequestedAbort = true;
   });
-
-  while (!userRequestedAbort) {
-    const timeoutSignal = AbortSignal.timeout(config.timeout);
-    const signals = [timeoutSignal];
-
-    if (userRequest.abortSignal) {
-      signals.push(userRequest.abortSignal);
-    }
-
+  const handle = new ErrorHandler();
+  for (let attempt = 0; attempt < (userRequest.retryAttempts ?? 50); attempt++) {
     try {
-      const response = await fetch(url("query-live", userRequest), {
-        signal: AbortSignal.any(signals),
-      });
-
-      if (response.status !== 200) {
-        if (response.status === 429) {
-          throw `Rate limited, retrying in ${config.delay}ms`;
-        } else if (response.status === 408) {
-          debug("Timeout error, retrying...");
-          // retry immediately
-          continue;
-        } else {
-          throw new Error(
-            `Index Supply API error: ${response.status} ${response.statusText}, retrying...`,
-          );
-        }
-      }
-
-      if (!response.body) {
-        throw new Error(`Index Supply API response missing body`);
-      }
-
-      const reader = response.body.getReader() as Stream;
-      attempt = 0; // Reset counter on successful connection
-
+      let request = new FetchRequest(url("query-live", userRequest));
+      let response = await sendRequest(request, userRequest.abortSignal);
+      const reader = response.body!.getReader() as Stream;
       for await (const payload of readStream(reader)) {
-        yield parseJSON(payload, userRequest.formatRow);
-      }
-    } catch (error) {
-      if (userRequestedAbort) return;
-
-      if (error instanceof Error && error.name === "AbortError") {
-        debug(`Restarting...`);
-        continue;
-      }
-
-      debug(`Error: ${error}`);
-      if (config.maxAttempts) {
-        if (attempt === config.maxAttempts) {
-          if (error instanceof Error) {
-            throw new Error(
-              `Failed after ${attempt} attempts: ${error.message}`,
-            );
-          }
-          throw error;
+        let parsed = JSON.parse(payload);
+        if (parsed.error === "user") {
+          throw new EUser(parsed.message);
+        } else if (parsed.error === "server") {
+          throw new EWait(parsed.error.server);
+        } else {
+          yield parseResponse(parsed, userRequest.formatRow);
+          attempt = 0;
         }
-
-        debug(
-          `Attempt ${attempt + 1}/${config.maxAttempts} failed, retrying in ${
-            config.delay
-          }ms`,
-        );
-      } else {
-        debug(`Attempt failed, retrying in ${config.delay}ms`);
       }
-
-      await delay(config.delay);
-
-      attempt++;
+    } catch (e) {
+      if (userRequestedAbort) return;
+      await handle.error("query-live", e);
     }
   }
+  throw handle.last;
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from 'node:assert/strict';
-import {query, queryLive } from "../src/index"
+import { query, queryLive } from "../src/index"
 
 test("query", async (t) => {
   await t.test("should work", async () => {
@@ -29,9 +29,9 @@ test("query", async (t) => {
 test("queryLive", async (t) => {
   const controller = new AbortController();
   await t.test("should work", async () => {
-    const query = await queryLive({
+    const query = queryLive({
       abortSignal: controller.signal,
-      startBlock: () => 2397612,
+      startBlock: () => 2397612n,
       chainId: 8453n,
       eventSignatures: [
         "Transfer(address indexed from, address indexed to, uint256 value)",


### PR DESCRIPTION
Upon testing, I realized that we need to deal with SSE errors within the context of the stream. The API was previously terminating the connection on _any_ error. It now will return a json encoded error in the stream. After thinking about this, I then realized that we could share the sending of the request and the HTTP related error checking between the query and queryLive functions.

There are still some loose ends to clean up with this particular direction, but I wanted to jot it down as a possible new approach to our error handling code.